### PR TITLE
Icon fix for Mysteries of Westgate

### DIFF
--- a/base/2da/nwn2_icons.2DA
+++ b/base/2da/nwn2_icons.2DA
@@ -2501,8 +2501,8 @@
 2497 ****
 2498 ****
 2499 ****
-2500 padding_Ossian
-2501 padding_Ossian
+2500 it_he_nightmask
+2501 it_qi_hamster
 2502 ****
 2503 ****
 2504 ****

--- a/base/credits.txt
+++ b/base/credits.txt
@@ -387,3 +387,11 @@ nwn2_icons.2DA
 x2_it_sparscr702.UTI [add]
 
 
+Icon fix for Mysteries of Westgate
+v.190507
+Add a couple of icon refs for MoW. Reported by Chofranc.
+files:
+- 2da
+nwn2_icons.2DA
+
+


### PR DESCRIPTION
Add a couple of icon refs for MoW. Reported by Chofranc.